### PR TITLE
Существенное улучшение производительности

### DIFF
--- a/quast_libs/ca_utils/analyze_misassemblies.py
+++ b/quast_libs/ca_utils/analyze_misassemblies.py
@@ -37,6 +37,8 @@ class Misassembly:
 
 
 class StructuralVariations(object):
+    __slots__ = ("inversions", "relocations", "translocations")
+
     def __init__(self):
         self.inversions = []
         self.relocations = []
@@ -47,6 +49,8 @@ class StructuralVariations(object):
 
 
 class Mapping(object):
+    __slots__ = ("s1", "e1", "s2", "e2", "len1", "len2", "idy", "ref", "contig", "cigar", "ns_pos", "sv_type")
+
     def __init__(self, s1, e1, s2=None, e2=None, len1=None, len2=None, idy=None, ref=None, contig=None, cigar=None, ns_pos=None, sv_type=None):
         self.s1, self.e1, self.s2, self.e2, self.len1, self.len2, self.idy, self.ref, self.contig = s1, e1, s2, e2, len1, len2, idy, ref, contig
         self.cigar = cigar
@@ -97,6 +101,8 @@ class Mapping(object):
 
 
 class IndelsInfo(object):
+    __slots__ = ("mismatches", "insertions", "deletions", "indels_list")
+
     def __init__(self):
         self.mismatches = 0
         self.insertions = 0


### PR DESCRIPTION
Привет!

Будучи опечаленным до глубины души тем, что каждый запуск `metaquast` у меня занимает час, а запускать его приходится часто, я решил заняться оптимизацией.

Довольно быстро выяснив, что `metaquast` почти всё время работы тратит на `analyze_contigs.py:94(analyze_contigs)` на фазе "Running Contig analyzer..." для комбинорованого референса (который, кстати говоря, мне не нужен, может как-то его можно просто отключить?), я добавил профилирование этой функции в одном из потоков.

<details>
<summary>Результат профилирования текущего мастера</summary>

![image](https://user-images.githubusercontent.com/25592720/149847450-7e5cee88-ec06-4498-a588-ba5395d4dce0.png)
</details>

Видно, что вызов `clone`, который вызывается для всех элементов в `best_set_selection.py:192(<listcomp>)`, съедает безумное количество времени. Если дальше посмотреть код, то мы меняем не больше 3х последних элементов, хотя копии сделали всех.
<details>
<summary>Поправив это недоразумение, я получил такой результат</summary>

![image](https://user-images.githubusercontent.com/25592720/149847625-71943c63-279a-4aaa-a110-634362c8fdba.png)
</details>

Также заметил, что набор полей объектов в файлах `best_set_selection.py` и `analyze_misassemblies.py` не меняется, поэтому добавил `__slots__` к классам в этих файлах.
<details>
<summary>Результат</summary>

![image](https://user-images.githubusercontent.com/25592720/149848073-2acd9c91-2473-49d2-b80b-e8726bc28cc0.png)
</details>

Итого, если верить профилировщику и времени работы, которое репортит quast, выигрыш получился где-то в 2 раза (что в моём случае около 30 минут на запуск!).

И да, выравнивание всех данных на референсы занимает около 40 секунд, что по сравнению с `analyze_contigs` пренебрежимо мало.

----------

Также попробовал вместо ванильного питона использовать `nuitka` и `pypy3`. `nuitka` скорость работы не изменил, а вот `pypy3` удалось поделить время **ещё** на 3 (что в моей случае в итоге стало занимать 10 минут вместо 60).

<details>
<summary>Вот профилирование с моими изменениями и с ним</summary>

![image](https://user-images.githubusercontent.com/25592720/149848582-5257df03-a55e-4c5c-aedd-483baff28c8c.png)
</details>

Поэтому, вероятно, стоит подумать над использование `pypy3` по-умолчанию. Или хотя бы настоятельно рекомендовать. 