### PR TITLE
fix: change read mode in `is_valid_bed`

### DIFF
--- a/quast_libs/ra_utils/misc.py
+++ b/quast_libs/ra_utils/misc.py
@@ -411,8 +411,8 @@ def is_valid_bed(bed_fpath):
                 lines_found = f.readlines()
                 break
             lines_found = f.readlines()
-        block_counter -= 1
-    for line in lines_found:
+            block_counter -= 1
+    for line in lines_found[-10:]:
         if not line.startswith(b'#'):
             fs = line.decode().split('\t')
             try:

--- a/quast_libs/ra_utils/misc.py
+++ b/quast_libs/ra_utils/misc.py
@@ -399,7 +399,7 @@ def sambamba_view(in_fpath, out_fpath, max_threads, err_fpath, logger, filter_ru
 
 def is_valid_bed(bed_fpath):
     # check last 10 lines
-    with open(bed_fpath, 'r') as f:
+    with open(bed_fpath, 'rb') as f:
         lines_found = []
         block_counter = -1
         _buffer = 1024
@@ -413,8 +413,8 @@ def is_valid_bed(bed_fpath):
             lines_found = f.readlines()
         block_counter -= 1
     for line in lines_found:
-        if not line.startswith('#'):
-            fs = line.split('\t')
+        if not line.startswith(b'#'):
+            fs = line.decode().split('\t')
             try:
                 align1 = (int(fs[1]), int(fs[2]), correct_name(fs[0]), fs[6])
                 align2 = (int(fs[4]), int(fs[5]), correct_name(fs[3]), fs[6])


### PR DESCRIPTION
Closes #230.

The error described in #230 is caused by opening the bed file in the `r` mode, which does not allow for seeking from the end of the file. This PR changes the mode to `rb` and adjusts the other two required lines to make that possible. 