### PR TITLE
Enable Minimap2 compilation on ARM64 platforms

### DIFF
--- a/quast_libs/qutils.py
+++ b/quast_libs/qutils.py
@@ -13,6 +13,7 @@ import hashlib
 import shutil
 import subprocess
 import os
+import platform
 import stat
 import sys
 import re
@@ -892,10 +893,18 @@ def compile_tool(name, dirpath, requirements, just_notice=False, logger=logger, 
             call_subprocess(['./configure'] + configure_args, stdout=open(make_logs_basepath + '.log', 'a'),
                             stderr=open(make_logs_basepath + '.err', 'a'))
             os.chdir(prev_dir)
+
+        current_make_command_parts = (['make', make_cmd] if make_cmd else ['make'])
+        if name == 'Minimap2' and (platform.machine() == 'arm64' or platform.machine() == 'aarch64'):
+            logger.main_info(f'Detected 64-bit ARM ({platform.machine()}). Applying ARM-specific make flags for Minimap2.')
+            current_make_command_parts.extend(['arm_neon=1', 'aarch64=1'])
+
+        final_make_command_for_subprocess = current_make_command_parts + ['-C', dirpath]
+        
         try:
-            return_code = call_subprocess((['make', make_cmd] if make_cmd else ['make']) + ['-C', dirpath],
-                                      stdout=open(make_logs_basepath + '.log', 'a'),
-                                      stderr=open(make_logs_basepath + '.err', 'a'), logger=logger)
+            return_code = call_subprocess(final_make_command_for_subprocess,
+                                          stdout=open(make_logs_basepath + '.log', 'a'),
+                                          stderr=open(make_logs_basepath + '.err', 'a'), logger=logger)
         except IOError:
             msg = 'Permission denied accessing ' + dirpath + '. Did you forget sudo?'
             if just_notice:


### PR DESCRIPTION
The bundled Minimap2 aligner in QUAST fails to compile on 64-bit ARM architectures (e.g., Apple Silicon Macs, Linux aarch64) due to the attempted compilation of SSE-specific code (like in ksw2_ll_sse.c). This results in a general 'ERROR! Compilation of contig aligner software was unsuccessful!'.

This commit modifies QUAST's  function. It now detects if the system is a 64-bit ARM architecture and if the tool being compiled is 'Minimap2'. If these conditions are met, the and flags are added to the command for Minimap2.

This approach utilizes Minimap2's standard Makefile, which includes support for ARM NEON compilation when these flags are provided (likely via sse2neon for relevant C files). This resolves the SSE-related compilation errors and enables QUAST to successfully compile and use its bundled Minimap2 on these ARM platforms.

Closes #283